### PR TITLE
GARfVDB: Fix MLP layer bug

### DIFF
--- a/instance_segmentation/garfvdb/evaluation/eval_nvos.py
+++ b/instance_segmentation/garfvdb/evaluation/eval_nvos.py
@@ -842,8 +842,8 @@ def run_nvos_evaluation(
     ref_model_input = GARfVDBInput(
         intrinsics=ref_K,
         projection=ref_K,
-        cam_to_world=ref_c2w,
         camera_to_world=ref_c2w,
+        world_to_camera=torch.linalg.inv(ref_c2w).contiguous(),
         image_w=[ref_img_w],
         image_h=[ref_img_h],
     )
@@ -851,8 +851,8 @@ def run_nvos_evaluation(
     test_model_input = GARfVDBInput(
         intrinsics=test_K,
         projection=test_K,
-        cam_to_world=test_c2w,
         camera_to_world=test_c2w,
+        world_to_camera=torch.linalg.inv(test_c2w).contiguous(),
         image_w=[test_img_w],
         image_h=[test_img_h],
     )


### PR DESCRIPTION
Fix a syntax issue where the MLP layer creation code was creating references to the same instance of a pair of hidden layers rather than 4 pairs

Precomputing the `world_to_camera` instead of inverting camera_to_world on every mask output evaluation