### PR TITLE
Add CODEOWNERS requiring NVIDIA maintainer review for governance/CI files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,23 @@
+# fVDB CODEOWNERS
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+#
+# This file is kept identical across the fvdb-core, fvdb-reality-capture,
+# and fvdb-examples repositories. Later matches take precedence over
+# earlier ones.
+
+# Default owner for all files: any fVDB maintainer may review.
+* @openvdb/fvdb-dev
+
+# Governance, legal, and CI/CD infrastructure require review from an
+# NVIDIA maintainer (fvdb-dev-nvidia, a child team of fvdb-dev). These
+# patterns match even when the file does not yet exist, so a non-NVIDIA
+# contributor cannot add one without an NVIDIA maintainer's approval.
+/.github/            @openvdb/fvdb-dev-nvidia
+/CODEOWNERS          @openvdb/fvdb-dev-nvidia
+/LICENSE             @openvdb/fvdb-dev-nvidia
+/MAINTAINERS.md      @openvdb/fvdb-dev-nvidia
+/CODE_OF_CONDUCT.md  @openvdb/fvdb-dev-nvidia
+/CONTRIBUTING.md     @openvdb/fvdb-dev-nvidia
+/SECURITY.md         @openvdb/fvdb-dev-nvidia
+/.gitmodules         @openvdb/fvdb-dev-nvidia

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # fVDB CODEOWNERS
-# See https://help.github.com/articles/about-codeowners/
+# See https://docs.github.com/articles/about-code-owners
 # for more info about CODEOWNERS file
 #
 # This file is kept identical across the fvdb-core, fvdb-reality-capture,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,5 @@
-All participants agree to abide by LF Projects Code of Conduct (as defined in the [charter](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/tsc/charter.md)) available at https://lfprojects.org/policies/code-of-conduct/
+# Code of Conduct
+
+All participants agree to abide by the LF Projects Code of Conduct (as defined in
+the [charter](https://github.com/AcademySoftwareFoundation/foundation/blob/main/project_charters/open-vdb_charter.pdf)),
+available at <https://lfprojects.org/policies/code-of-conduct/>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-All participants agree to abide by LF Projects Code of Conduct (as defined in the [charter](tsc/charter.md)) available at https://lfprojects.org/policies/code-of-conduct/
+All participants agree to abide by LF Projects Code of Conduct (as defined in the [charter](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/tsc/charter.md)) available at https://lfprojects.org/policies/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The contributor role is the starting role for anyone participating in the projec
 ### Process for becoming a contributor
 
 * Review the [coding standards](https://www.openvdb.org/documentation/doxygen/codingStyle.html) to ensure your contribution is in line with the project's coding and styling guidelines.
-* Have a signed CLA on file ( see [below](#contributor-license-agreements) )
+* Have a signed CLA on file (see [below](#contributor-license-agreements)).
 * Submit your code as a PR with the appropriate [DCO sign-off](#commit-sign-off).
 * Have your submission approved by the [maintainer(s)](#maintainer) and merged into the codebase.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ The contributor role is the starting role for anyone participating in the projec
 * Review the [coding standards](https://www.openvdb.org/documentation/doxygen/codingStyle.html) to ensure your contribution is in line with the project's coding and styling guidelines.
 * Have a signed CLA on file ( see [below](#contributor-license-agreements) )
 * Submit your code as a PR with the appropriate [DCO sign-off](#commit-sign-off).
-* Have your submission approved by the [committer(s)](#committer) and merged into the codebase.
+* Have your submission approved by the [maintainer(s)](#maintainer) and merged into the codebase.
 
 ### Legal Requirements
 
@@ -22,7 +22,7 @@ open source software best practice policies of the Linux Foundation.
 
 #### License
 
-ƒVDB is licensed under the [Apache License, version 2.0](LICENSE.md)
+ƒVDB is licensed under the [Apache License, version 2.0](LICENSE)
 license. Contributions to ƒVDB should abide by that standard
 license.
 
@@ -46,7 +46,7 @@ can be merged.
   Agreement](https://docs.linuxfoundation.org/lfx/easycla/contributors/corporate-contributor).
 
 The ƒVDB CLAs are the standard forms used by Linux Foundation
-projects and [recommended by the ASWF TAC](https://github.com/AcademySoftwareFoundation/tac/blob/master/process/contributing.md#contributor-license-agreement-cla). You can review the text of the CLAs in the [TSC directory](tsc/).
+projects and [recommended by the ASWF TAC](https://github.com/AcademySoftwareFoundation/tac/blob/master/process/contributing.md#contributor-license-agreement-cla). You can review the text of the CLAs in the [TSC directory](https://github.com/AcademySoftwareFoundation/openvdb/tree/master/tsc).
 
 #### Commit Sign-Off
 
@@ -54,7 +54,7 @@ Every commit must be signed off.  That is, every commit log message
 must include a “`Signed-off-by`” line (generated, for example, with
 “`git commit --signoff`”), indicating that the committer wrote the
 code and has the right to release it under the
-[Apache License, version 2.0](LICENSE.md)
+[Apache License, version 2.0](LICENSE)
 license. See the [TAC documentation on contribution sign off](https://github.com/AcademySoftwareFoundation/tac/blob/master/process/contributing.md#contribution-sign-off) for more information on this requirement.
 
 ## Maintainer
@@ -68,7 +68,7 @@ This role enables the participant to commit code directly to the repository, but
 * Show your experience with the codebase through contributions and engagement on the community channels.
 * Request to become a maintainer.
 * Have the majority of maintainers approve you becoming a maintainer.
-* Your name and email is added to the MAINTAINERS.md file for the project.
+* Your name and email are added to the MAINTAINERS.md file for the project.
 
 ### Maintainer responsibilities
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenVDB project. -->
+
+# fVDB Maintainers
+
+The current fVDB maintainers are:
+
+| Name                | Email                     |
+| ------------------- | ------------------------- |
+| Ken Museth          | ken.museth@gmail.com      |
+| Jonathan Swartz     | jonathan@jswartz.info     |
+| Francis Williams    | francis@fwilliams.info    |
+| Mark Harris         | mharris@nvidia.com        |
+| Matthew Cong        | mcong@nvidia.com          |
+| Andrew Reidmeyer    | areidmeyer@nvidia.com     |
+| Christopher Horvath | blackencino+git@gmail.com |
+| Eftychios Sifakis   | esifakis@nvidia.com       |
+| Petra Hapalova      | phapalova@nvidia.com      |


### PR DESCRIPTION
## What

Split `CODEOWNERS` into two review tiers:

- **Default (`@openvdb/fvdb-dev`)** — any maintainer may review code.
- **`@openvdb/fvdb-dev-nvidia`** (child team of `fvdb-dev`) — required for governance, legal, and CI/CD infrastructure: `.github/`, `CODEOWNERS`, `LICENSE`, `MAINTAINERS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `.gitmodules`.

## Why

Certain files (legal, governance, release/CI automation) should require sign-off from an NVIDIA maintainer. The listed patterns match files **even before they exist**, so a non-NVIDIA contributor cannot introduce e.g. a `MAINTAINERS.md` or `SECURITY.md` without NVIDIA approval.

This `CODEOWNERS` is kept **identical** across `fvdb-core`, `fvdb-reality-capture`, and `fvdb-examples`.

## Note for reviewers

For enforcement, each repo's branch protection must have *"Require review from Code Owners"* enabled, and `fvdb-dev-nvidia` must have explicit write access to the repo (child-team status does not inherit repo access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)