### PR TITLE
CI: don't skip required code-style checks on docs-only PRs

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -3,9 +3,6 @@ on:
     pull_request:
       branches:
         - main
-      paths-ignore:
-          - 'CODEOWNERS'
-          - '**.md'
 
 # Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
 concurrency:


### PR DESCRIPTION
## Problem

Docs-only PRs (e.g. the CODEOWNERS PR #62) are stuck **BLOCKED**. The `main` ruleset marks the code-style checks (black, include guards, SPDX, whitespace) as **required**, but `codestyle.yml` used workflow-level `paths-ignore` for `**.md`/`CODEOWNERS`. A workflow skipped via `paths-ignore` never reports its checks, so the required checks sit at "Expected" forever and block the merge.

## Fix

Remove `paths-ignore` from `codestyle.yml`. The lint jobs are cheap (ubuntu-latest) and now always run and report, satisfying the required checks on every PR including docs-only ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)